### PR TITLE
tweaking some wording

### DIFF
--- a/src/Endpoint/IEndpoint/IEndpointFunctionsForApps.sol
+++ b/src/Endpoint/IEndpoint/IEndpointFunctionsForApps.sol
@@ -11,43 +11,43 @@ interface IEndpointFunctionsForApps {
     /**
      * @dev - Function that allows application to select its send and receive module
      *        and set their initial configs
-     * @param _libraryName - name of the library the application is selecting.
-     * @param _sendModuleConfigs - bytes array containing encoded configs to be
-     *                             passed to the send module on the applications behalf
-     * @param _receiveModuleConfigs - bytes array containing encoded configs to be passed
-     *                                to the receive module on the applications behalf
+     * @param _libraryName - name of the library the application is selecting
+     * @param _appConfigForSending - bytes array containing encoded configs to be
+     *                               passed to the send module on the applications behalf
+     * @param _appConfigForReceiving - bytes array containing encoded configs to be passed
+     *                                 to the receive module on the applications behalf
      * @return sendModule - address of the sendModule
      * @return receiveModule - address of the receiveModule
      */
     function setLibraryAndConfigs(
         string calldata _libraryName,
-        bytes calldata _sendModuleConfigs,
-        bytes calldata _receiveModuleConfigs
+        bytes calldata _appConfigForSending,
+        bytes calldata _appConfigForReceiving
     ) external returns (address sendModule, address receiveModule);
 
     /**
      * @dev - Function that allows application to update its library's send module configs
-     * @param _sendModuleConfigs - bytes array containing encoded configs to be passed to
+     * @param _appConfigForSending - bytes array containing encoded configs to be passed to
      *                             the send module on the applications behalf
      */
-    function updateSendModuleConfigs(bytes calldata _sendModuleConfigs) external;
+    function updateAppConfigForSending(bytes calldata _appConfigForSending) external;
 
     /**
      * @dev - Function that allows application to update its library's receive module configs
-     * @param _receiveModuleConfigs - bytes array containing encoded configs to be passed
+     * @param _appConfigForReceiving - bytes array containing encoded configs to be passed
      *                                to the receive module on the applications behalf
      */
-    function updateReceiveModuleConfigs(bytes calldata _receiveModuleConfigs) external;
+    function updateAppConfigForReceiving(bytes calldata _appConfigForReceiving) external;
 
     /**
-     * @dev - Function that allows the application to send message to its designated library to be broadcasted
+     * @dev - Function that applications call to broadcast a message via its selected library's SendModule
      *        if it is not self-broadcasting
-     * @param _receiverInstanceId - bytes32 indicating the instance id of the endpoint that is receiving the message
-     * @param _receiver - bytes array indicating the address of the receiver.
+     * @param _receiverInstanceId - bytes32 indicating the instance id of the receiver's earlybird endpoint
+     * @param _receiver - bytes array indicating the address of the receiver
      *                    (bytes is used since the receiver can be on an EVM or non-EVM chain)
      * @param _payload - bytes array containing the message payload to be delivered to the receiver
-     * @param _additionalParams - bytes array containing additional params application would like to passed to the library.
-     *                            May be used in the library to enable special functionality.
+     * @param _additionalParams - bytes array containing additional params application would like to passed to the library
+     *                            May be used in the library to enable special functionality
      */
     function sendMessage(
         bytes32 _receiverInstanceId,
@@ -58,9 +58,9 @@ interface IEndpointFunctionsForApps {
 
     /**
      * @dev - Function allows anyone to retry delivering a failed message
-     * @param _app - address of the app the message is being delivered to.
+     * @param _app - address of the app receiving the message
      * @param _senderInstanceId - bytes32 indicating the instance id of the earlybird endpoint from 
-     *                            which the sender is sending the message.
+     *                            which the sender is sending the message
      * @param _sender - bytes indicating the address of the sender app
      *                  (bytes is used since the sender can be on an EVM or non-EVM chain)
      * @param _nonce - uint256 indicating the nonce or id of the failed message

--- a/src/Endpoint/IEndpoint/IEndpointFunctionsForLibraries.sol
+++ b/src/Endpoint/IEndpoint/IEndpointFunctionsForLibraries.sol
@@ -5,17 +5,17 @@ pragma solidity ^0.8.17;
 /**
  * @author - Orb Labs
  * @title  - IEndpointFunctionsForLibraries
- * @notice - Interface for Endpoint functions that only the library can call.
+ * @notice - Interface for Endpoint functions that only the library can call
  */
 interface IEndpointFunctionsForLibraries {
     /**
-     * @dev - Function that allows the library to deliver messages to applications that use it
-     * @param _app - address of the app the message is being delivered to.
-     * @param _senderInstanceId - bytes32 indicating the instance id of the endpoint from which the message is being sent.
-     * @param _sender - bytes array indicating the address of the app sending the message.
+     * @dev - Function that the library will call to deliver messages to applications via the endpoint
+     * @param _app - address of the app receiving the message
+     * @param _senderInstanceId - bytes32 indicating the id of the sender's earlybird instance
+     * @param _sender - bytes array indicating the address of the app sending the message
      *                  (bytes is used since the receiver can be on an EVM or non-EVM chain)
      * @param _nonce - nonce of the message
-     * @param _payload - bytes array indicating the message payload.
+     * @param _payload - bytes array indicating the message payload
      * @param _additionalInfo - bytes array containing additional information the library would like to pass to _app
      */
     function deliverMessageToApp(
@@ -29,10 +29,10 @@ interface IEndpointFunctionsForLibraries {
 
     /**
      * @dev - Function that allows the library to collect ERC20 Fee from App for the library
-     * @param _app - address of the app we are collecting fees from
+     * @param _app - address of the app to collect fees from
      * @param _token - address for the token
      * @param _feeTo - address of the person the tokens should be transferred to
-     * @param _amount - uint256 indicating the amount of tokens that should be transferred.
+     * @param _amount - uint256 indicating the amount of tokens that should be transferred
      */
     function collectTokenFromAppForLibrary(address _app, address _token, address _feeTo, uint256 _amount)
         external;

--- a/src/Endpoint/IEndpoint/IEndpointGetFunctions.sol
+++ b/src/Endpoint/IEndpoint/IEndpointGetFunctions.sol
@@ -21,10 +21,10 @@ interface IEndpointGetFunctions {
     /**
      * @dev - Function returns a library's info give a library name
      * @param _libraryName - string indicating the library's name
-     * @return libraryId - uint256 indicating the id of the library
-     * @return sendModule - address of the send module
-     * @return receiveModule - address of the receive module
-     * @return isDeprecated - boolean telling us whether the library is deprecated or not
+     * @return libraryId - uint256 indicating the library's id
+     * @return sendModule - address of the library's send module
+     * @return receiveModule - address of the library's receive module
+     * @return isDeprecated - boolean of whether the library is deprecated or not
      */
     function getLibraryInfo(string calldata _libraryName)
         external
@@ -33,11 +33,11 @@ interface IEndpointGetFunctions {
 
     /**
      * @dev - Function returns an application's selected library and info
-     * @param _app - Address of the application
-     * @return libraryName - string indicating the library's name
-     * @return libraryId - uint256 indicating the id of the library
-     * @return sendModule - address of the send module
-     * @return receiveModule - address of the receive module
+     * @param _app - address of an application to look up
+     * @return libraryName - string indicating the app's selected library's name
+     * @return libraryId - uint256 indicating the app's selected library's id
+     * @return sendModule - address of the app's selected library's send module
+     * @return receiveModule - address of the app's selected library's receive module
      * @return isDeprecated - boolean telling us whether the library is deprecated or not
      */
     function getLibrary(address _app)
@@ -47,10 +47,10 @@ interface IEndpointGetFunctions {
 
     /**
      * @dev - Function returns the info for a library with a particular library id
-     * @param _libraryId - uint256 indicating the id of a library
+     * @param _libraryId - uint256 id of the library to look up
      * @return libraryName - string indicating the library's name
-     * @return sendModule - address of the send module
-     * @return receiveModule - address of the receive module
+     * @return sendModule - address of the library's send module
+     * @return receiveModule - address of the library's receive module
      * @return isDeprecated - boolean telling us whether the library is deprecated or not
      */
     function getLibraryById(uint256 _libraryId)
@@ -59,10 +59,10 @@ interface IEndpointGetFunctions {
         returns (string memory libraryName, address sendModule, address receiveModule, bool isDeprecated);
 
     /**
-     * @dev - Function returns the library Fee settings
+     * @dev - Function returns a given library's fee settings for a given module type
      * @param _libraryName - string indicating the name of library
      * @param _moduleType - uint256 indicating the module type
-     * @return protocolFeeSettings - bytes containing an app's send library configs
+     * @return protocolFeeSettings - bytes containing fee settings for the library
      */
     function getProtocolFeeSettings(string calldata _libraryName, uint256 _moduleType)
         external
@@ -70,12 +70,12 @@ interface IEndpointGetFunctions {
         returns (bytes memory protocolFeeSettings);
 
     /**
-     * @dev - Function returns the library Fee settings
-     * @param _app - string indicating the name of library
+     * @dev - Function returns information about fees on a given module type for the library selected by a given app
+     * @param _app - string indicating the name of an application to look up
      * @param _moduleType - uint256 indicating the module type
-     * @return isProtocolFeeOn - bool indicating whether protocol fees are on or not.
-     * @return protocolFeeToken - address of the token accepted as protocol fees.
-     * @return protocolFeeAmount - amount of the token accepted for protocol fees.
+     * @return isProtocolFeeOn - bool indicating whether protocol fees are on or not
+     * @return protocolFeeToken - address of the token accepted as protocol fees
+     * @return protocolFeeAmount - amount of the token to be paid as protocol fees
      */
     function getProtocolFee(address _app, uint256 _moduleType)
         external
@@ -85,24 +85,25 @@ interface IEndpointGetFunctions {
     /**
      * @dev - Function returns the app's send module configs
      * @param _app - Address of the application
-     * @return sendModuleConfigs - bytes containing an app's send module configs
+     * @return appConfigForSendModule - bytes containing an app's send module configs
      */
-    function getSendModuleConfigs(address _app) external returns (bytes memory sendModuleConfigs);
+    function getAppConfigForSending(address _app) external returns (bytes memory appConfigForSendModule);
 
     /**
      * @dev - Function returns the app's receive module configs
      * @param _app - Address of the application
-     * @return receiveModuleConfigs - bytes containing an app's receive module configs
+     * @return appConfigForReceiveModule - bytes containing an app's receive module configs
      */
-    function getReceiveModuleConfigs(address _app) external returns (bytes memory receiveModuleConfigs);
+    function getAppConfigForReceiving(address _app) external returns (bytes memory appConfigForReceiveModule);
 
     /**
-     * @dev - Function returns the sending nonce for app when it is sending messages to the receiver on the receiverInstanceId
-     *        through libraryName. App has a different nonce for each receiver on each endpoint instance to which it sends messages.
-     * @param _libraryName - string indicating name of the library whose sending library nonce is being returned
-     * @param _app - address of the application that has been sending the messages
-     * @param _receiverInstanceId - bytes32 indicating the instance id of the receiver's endpoint
-     * @param _receiver - bytes array indicating the receiver's address
+     * @dev - Function returns the sending nonce for a given set of 
+     *        app sending messages, library, receiver, and earlybird instance Id
+     *        (each unique set has its own nonce)
+     * @param _libraryName - string indicating name of the library whose sending nonce is being returned
+     * @param _app - address of the application sending messages
+     * @param _receiverInstanceId - bytes32 indicating the instance id of the receiver's earlybird endpoint
+     * @param _receiver - bytes array indicating the address of the receiver
      *                    (bytes is used since the receiver can be from an EVM or non-EVM chain)
      * @return sendingNonce - uint256 indicating the outbound nonce
      */
@@ -114,11 +115,12 @@ interface IEndpointGetFunctions {
     ) external view returns (uint256 sendingNonce);
 
     /**
-     * @dev - Function returns the receiving nonce for app when it is receiving messages from sender on the senderInstanceId
-     *        through libraryName. App has a different nonce for each sender on each endpoint instance from which it receives messages.
-     * @param _libraryName - string indicating name of the library whole receive library nonce is being returned
-     * @param _app - address of the application that has been receiving the messages
-     * @param _senderInstanceId - bytes32 indicating the id of the sender's endpoint instance id
+     * @dev - Function returns the receiving nonce for a given set of 
+     *        app sending messages, library, receiver, and earlybird instance Id
+     *        (each unique set has its own nonce)
+     * @param _libraryName - string indicating name of the library whose receiving nonce is being returned
+     * @param _app - address of the application receiving messages
+     * @param _senderInstanceId - bytes32 indicating the id of the sender's earlybird instance
      * @param _sender - bytes array indicating the sender's address
      *                  (bytes is used since the sender can be from an EVM or non-EVM chain)
      * @return receivingNonce - uint256 indicating the inbound nonce
@@ -130,13 +132,13 @@ interface IEndpointGetFunctions {
 
     /**
      * @dev - Function returns whether a token is accepted as a sending fee and the amount of the tokens
-     *        the app would have to pay to send a message from one instance to another.
-     * @param _app - Address of the app sending the message.
-     * @param _receiverInstanceId - bytes32 indicating the receiver's endpoint instance Id
+     *        the app would have to pay to send a message from one instance to another
+     * @param _app - Address of the app sending the message
+     * @param _receiverInstanceId - bytes32 indicating the instance id of the receiver's earlybird endpoint
      * @param _receiver - bytes array indicating the address of the receiver
      *                    (bytes is used since the receiver can be on an EVM or non-EVM chain)
      * @param _payload - bytes array containing message payload
-     * @param _additionalParams - bytes array containing additional params.
+     * @param _additionalParams - bytes array containing additional params
      * @return isTokenAccepted - bool indicating whether the token passed in the additional params is accepted
      * @return feeEstimate - uint256 indicating the sendingFeeEstimate
      */
@@ -149,14 +151,14 @@ interface IEndpointGetFunctions {
     ) external view returns (bool isTokenAccepted, uint256 feeEstimate);
 
     /**
-     * @dev - Function returns all the tokens accepted as fees for sending messages.
-     * @param _app - Address of the app sending the message.
-     * @param _receiverInstanceId - bytes32 indicating the receiver endpoint instance Id
+     * @dev - Function returns all the tokens accepted as fees for sending messages
+     * @param _app - Address of the app sending the message
+     * @param _receiverInstanceId - bytes32 indicating the instance id of the receiver's earlybird endpoint
      * @param _receiver - bytes array indicating the address of the receiver
      *                    (bytes is used since the receiver can be from an EVM or non-EVM chain)
      * @param _payload - bytes array containing message payload
      * @return acceptedTokens - array containing the address of all the tokens accepted as fee by the
-     *                          library sending the message. Native tokens are represented as the address(0).
+     *                          library sending the message. Native tokens are represented as the address(0)
      */
     function getAcceptedTokensForSendingFees(
         address _app,
@@ -168,15 +170,15 @@ interface IEndpointGetFunctions {
     /**
      * @dev - Function returns fee caller must pay before they are able to retry delivering the failed message
      * @param _libraryName - string indicating name of the library whole receive library nonce is being returned
-     * @param _app - address of the app the message is being delivered to.
+     * @param _app - address of the app meant to receive the message
      * @param _senderInstanceId - bytes32 indicating the instance id of the sender's endpoint
      * @param _sender - bytes indicating the address of the sender
      *                  (bytes is used since the sender can be from an EVM or non-EVM chain)
      * @param _nonce - uint256 indicating the index of the failed message in the array of failed messages
-     * @return failedMsgHash - bytes32 indicating the hash of the failed msg.
+     * @return failedMsgHash - bytes32 indicating the hash of the failed msg
      * @return feeForFailedMessage - uint256 indicating the fee caller must pay to relayer before
      *                               they are able to retry delivering the failed message
-     * @return relayerThatDeliveredMsg - address of relayer that delivered the failed msg.
+     * @return relayerThatDeliveredMsg - address of relayer that delivered the failed msg
      */
     function getFailedMessageByNonce(
         string calldata _libraryName,
@@ -189,7 +191,7 @@ interface IEndpointGetFunctions {
     /**
      * @dev - Function returns array of hashes of failed messages sent from a sender on senderInstanceId through libraryName
      * @param _libraryName - string indicating name of the library whole receive library nonce is being returned
-     * @param _app - address of the app the message is being delivered to.
+     * @param _app - address of the app meant to receive the message
      * @param _senderInstanceId - bytes32 indicating the instance id of the sender's endpoint
      * @param _sender - bytes indicating the address of the sender app
      *                  (bytes is used since the sender can be from an EVM or non-EVM chain)

--- a/src/FeeCollector/IFeeCollector.sol
+++ b/src/FeeCollector/IFeeCollector.sol
@@ -9,9 +9,9 @@ pragma solidity ^0.8.17;
  */
 interface IFeeCollector {
     /**
-     * @dev - function returns the amount an oracle is willing to charge for passing a message
+     * @dev - function estimates the amount the oracle/ relayer demands for passing a message
      * @param _app - Address of the application
-     * @param _receiverInstanceId - bytes32 indicating the receiver's endpoint instance Id
+     * @param _receiverInstanceId - bytes32 indicating the instance id of the receiver's earlybird endpoint
      * @param _receiver - bytes array indicating the address of the receiver
      * @param _payload - bytes array containing message payload
      * @param _additionalParams - bytes array containing additional params application would like
@@ -31,7 +31,7 @@ interface IFeeCollector {
     /**
      * @dev - function returns an array of tokens that are accepted as fees by the oracle
      * @param _app - Address of the application
-     * @param _receiverInstanceId - bytes32 indicating the receiver's endpoint instance Id
+     * @param _receiverInstanceId - bytes32 indicating the instance id of the receiver's earlybird endpoint
      * @param _receiver - bytes array indicating the address of the receiver
      * @param _payload - bytes array containing message payload
      * @return acceptedTokens - return array of address of tokens that it accepts.
@@ -47,7 +47,7 @@ interface IFeeCollector {
      * @dev - function returns whether a token is accepted as for fees or not.
      * @param _tokens - address of tokens we are inquirying about
      * @param _app - Address of the application
-     * @param _receiverInstanceId - bytes32 indicating the receiver's endpoint instance Id
+     * @param _receiverInstanceId - bytes32 indicating the instance id of the receiver's earlybird endpoint
      * @param _receiver - bytes array indicating the address of the receiver
      * @param _payload - bytes array containing message payload
      * @return areAcceptedTokens - return array of address of tokens that it accepts.

--- a/src/IReceiver/IReceiver.sol
+++ b/src/IReceiver/IReceiver.sol
@@ -10,7 +10,7 @@ pragma solidity ^0.8.17;
 interface IReceiver {
     /**
      * @dev - Function that allows the app to receive messages from the endpoint.
-     * @param _senderInstanceId - bytes32 indicating instance id of sender's endpoint.
+     * @param _senderInstanceId - bytes32 indicating the id of the sender's earlybird instance
      * @param _sender - bytes array indicating entity or application that sent the message.
      *                  (bytes is used since the sender can be on an EVM or non-EVM chain)
      * @param _payload - bytes array containing the message being delivered.

--- a/src/Libraries/ILibrary/IRequiredReceiveModuleFunctions.sol
+++ b/src/Libraries/ILibrary/IRequiredReceiveModuleFunctions.sol
@@ -40,7 +40,7 @@ interface IRequiredReceiveModuleFunctions is IRequiredModuleFunctions {
      * @dev - Function returns fee caller must pay to receive module before they are able to retry
      *        delivering the failed message
      * @param _app - address of the app the message is being delivered to.
-     * @param _senderInstanceId - bytes32 indicating the instance id of the sender's earlybird instance
+     * @param _senderInstanceId - bytes32 indicating the id of the sender's earlybird instance
      * @param _sender - bytes indicating the address of the sender
      *                  (bytes is used since the sender can be on an EVM or non-EVM chain)
      * @param _nonce - uint256 indicating the index of the failed message in the array of failed messages
@@ -57,7 +57,7 @@ interface IRequiredReceiveModuleFunctions is IRequiredModuleFunctions {
     /**
      * @dev - Function allows anyone to retry delivering a failed message
      * @param _app - address of the app the message is being delivered to.
-     * @param _senderInstanceId - bytes32 indicating the sender's earlybird instance id
+     * @param _senderInstanceId - bytes32 indicating the id of the sender's earlybird instance
      * @param _sender - bytes indicating the address of the sender
      *                  (bytes is used since the sender can be an EVM or non-EVM chain)
      * @param _nonce - uint256 indicating the nonce or id of the failed message.

--- a/src/Libraries/ILibrary/IRequiredSendModuleFunctions.sol
+++ b/src/Libraries/ILibrary/IRequiredSendModuleFunctions.sol
@@ -14,7 +14,7 @@ interface IRequiredSendModuleFunctions is IRequiredModuleFunctions {
     /**
      * @dev - Function returns the estimate for sending a message.
      * @param _app - address of the application
-     * @param _receiverInstanceId - bytes32 indicating the receiver's earlybird instance Id
+     * @param _receiverInstanceId - bytes32 indicating the instance id of the receiver's earlybird endpoint
      * @param _receiver - bytes array indicating the address of the receiver
      *                    (bytes is used since the receiver can be on an EVM or non-EVM chain)
      * @param _payload - bytes array containing message payload
@@ -37,7 +37,7 @@ interface IRequiredSendModuleFunctions is IRequiredModuleFunctions {
      *        Each app has a different nonce for each receiver on each earlybird instance to which it sends messages.
      * @param _app - address of the application that has been sending the messages
      * @param _receiverInstanceId - bytes32 indicating the instance id of the receiver's earlybird endpoint
-     * @param _receiver - bytes array indicating the receiver's address
+     * @param _receiver - bytes array indicating the address of the receiver
      */
     function getSendingNonce(address _app, bytes32 _receiverInstanceId, bytes memory _receiver)
         external

--- a/src/Libraries/Rukh/RukhReceiveModule/IRecsContractForRukhReceiveModule.sol
+++ b/src/Libraries/Rukh/RukhReceiveModule/IRecsContractForRukhReceiveModule.sol
@@ -13,7 +13,7 @@ pragma solidity ^0.8.17;
 interface IRecsContractForRukhReceiveModule {
     /**
      * @dev - function returns the amount an oracle is willing to charge for passing a message
-     * @param _senderInstanceId - bytes32 indicating the receiver's earlybird endpoint instance Id
+     * @param _senderInstanceId - bytes32 indicating the id of the sender's earlybird instance
      * @param _sender - bytes array indicating the address of the receiver
      * @param _nonce - uint256 indicating the nonce
      * @param _payload - bytes array containing message payload
@@ -34,7 +34,7 @@ interface IRecsContractForRukhReceiveModule {
 
     /**
      * @dev - function returns the amount an oracle is willing to charge for passing a message
-     * @param _senderInstanceId - bytes32 indicating the receiver's earlybird endpoint instance Id
+     * @param _senderInstanceId - bytes32 indicating the id of the sender's earlybird instance
      * @param _sender - bytes array indicating the address of the receiver
      * @param _nonce - uint256 indicating the nonce
      * @param _payload - bytes array containing message payload

--- a/src/Libraries/Rukh/RukhReceiveModule/IRukhReceiveModule.sol
+++ b/src/Libraries/Rukh/RukhReceiveModule/IRukhReceiveModule.sol
@@ -11,7 +11,7 @@ import "../../ILibrary/IRequiredReceiveModuleFunctions.sol";
  */
 interface IRukhReceiveModule is IRequiredReceiveModuleFunctions {
     /**
-     * @dev - Enum representing config type being updated
+     * @dev - Enum representing the app config changes that can be made
      * MIN_DISPUTE_TIME_CHANGE - represents the app's minimum dispute time as the variable being updated.
      * MIN_DISPUTE_RESOLUTION_EXTENSION_CHANGE - represents the app's dispute resolution extension period being updated.
      * DISPUTE_EPOCH_LENGTH_CHANGE - represents the app's dispute epoch length being updated.
@@ -26,7 +26,7 @@ interface IRukhReceiveModule is IRequiredReceiveModuleFunctions {
      * MSG_DELIVERY_PAUSED_STATUS_CHANGE - represents the app's msg delivery status being updated.
      * ORDERED_MSG_NONCE_CHANGE - represents the app's ordered msg nonce being updated.
      */
-    enum ConfigType {
+    enum ConfigUpdateType {
         MIN_DISPUTE_TIME_CHANGE,
         MIN_DISPUTE_RESOLUTION_EXTENSION_CHANGE,
         DISPUTE_EPOCH_LENGTH_CHANGE,
@@ -71,14 +71,14 @@ interface IRukhReceiveModule is IRequiredReceiveModuleFunctions {
     }
 
     /**
-     * @dev - Struct that represents an app's setting within the Rukh receive module
+     * @dev - Struct that represents an app config within the Rukh receive module
      * minDisputeTime - uint256 indicating the minimum dispute time for each message.
      *                  The recommended dispute time passed by the oracle must exceed this number.
      * minDisputeResolutionExtension - uint256 indicating how long the dispute resolution period should be extended after each dispute.
      * disputeEpochLength - uint256 indicating the number of blocks in a dispute epoch.
      * maxValidDisputesPerEpoch - uint256 indicating the maximum number of valid disputes that can occur in a dispute
      *                            epoch before the library assumes that the oracle has been compromised and pauses msg delivery.
-     * oracle - address of app's selected oracle
+     * oracle - address of oracle from which the app receives message proofs
      * defaultRelayer - address of app's default relayer.  The default relayer is typically responsible for passing
      *                  messages to the app except if the application has configured another relayer to pass messages
      *                  through the variable configs contract.
@@ -91,7 +91,7 @@ interface IRukhReceiveModule is IRequiredReceiveModuleFunctions {
      * msgDeliveryPaused - bool indicating whether msg delivery is paused or not. If paused, the library will not accept new msg
      *                     proofs or deliver messages to the app.
      */
-    struct AppSettings {
+    struct AppConfig {
         uint256 minDisputeTime;
         uint256 minDisputeResolutionExtension;
         uint256 disputeEpochLength;

--- a/src/Libraries/Rukh/RukhSendModule/IRukhSendModule.sol
+++ b/src/Libraries/Rukh/RukhSendModule/IRukhSendModule.sol
@@ -48,8 +48,8 @@ interface IRukhSendModule is IRequiredSendModuleFunctions {
      */
     struct AppConfig {
         bool isSelfBroadcasting;
-        address oracle;
-        address relayer;
+        address oracleFeeCollector;
+        address relayerFeeCollector;
     }
 
     /**

--- a/src/Libraries/Rukh/RukhSendModule/IRukhSendModule.sol
+++ b/src/Libraries/Rukh/RukhSendModule/IRukhSendModule.sol
@@ -11,13 +11,13 @@ import "../../ILibrary/IRequiredSendModuleFunctions.sol";
  */
 interface IRukhSendModule is IRequiredSendModuleFunctions {
     /**
-     * @dev - Enum representing config type the app would like updated.
+     * @dev - Enum representing the app config changes that can be made
      * BROADCAST_STATUS_CHANGE - represents broadcasting status being updated
      * ORACLE_CHANGE - represents oracle address being updated
      * RELAYER_CHANGE - represents relayer address being updated
-     * NONCE_CHANGE - represents the app's msg nonce being updated.
+     * NONCE_CHANGE - represents the app's msg nonce being updated
      */
-    enum ConfigType {
+    enum ConfigUpdateType {
         BROADCAST_STATUS_CHANGE,
         ORACLE_CHANGE,
         RELAYER_CHANGE,
@@ -41,12 +41,12 @@ interface IRukhSendModule is IRequiredSendModuleFunctions {
     }
 
     /**
-     * @dev - Struct representing an app's settings
+     * @dev - Struct representing an app's config
      * isSelfBroadcasting - bool on whether the app is self broadcasting or not.
-     * oracle - address of app's selected oracle revenue collection service
-     * relayer - address of app's selected relayer revenue collection service
+     * oracleFeeCollector - address to which the app will pay oracle fees
+     * relayerFeeCollector - address to which the app will pay relayer fees
      */
-    struct AppSettings {
+    struct AppConfig {
         bool isSelfBroadcasting;
         address oracle;
         address relayer;
@@ -123,16 +123,16 @@ interface IRukhSendModule is IRequiredSendModuleFunctions {
     /**
      * @dev - Event emitted when you self broadcast a message
      * @param msgHash - hash of the msg that the app delivered
-     * @param oracle - oracle address
-     * @param relayer - relayer address
+     * @param oracleFeeCollector - address to which oracle fees were paid
+     * @param relayerFeeCollector - address to which relayer fees were paid
      * @param feeToken - token that the fee was paid in
      * @param oracleFee - fee paid to the oracle
      * @param relayerFee - fee paid to the relayer
      */
     event OracleAndRelayerPaid(
         bytes32 indexed msgHash,
-        address indexed oracle,
-        address indexed relayer,
+        address indexed oracleFeeCollector,
+        address indexed relayerFeeCollector,
         address feeToken,
         uint256 oracleFee,
         uint256 relayerFee

--- a/src/Libraries/Thunderbird/ThunderbirdReceiveModule/IRecsContractForThunderbirdReceiveModule.sol
+++ b/src/Libraries/Thunderbird/ThunderbirdReceiveModule/IRecsContractForThunderbirdReceiveModule.sol
@@ -14,7 +14,7 @@ pragma solidity ^0.8.17;
 interface IRecsContractForThunderbirdReceiveModule {
     /**
      * @dev - function returns the amount an oracle is willing to charge for passing a message
-     * @param _senderInstanceId - bytes32 indicating the receiver's earlybird endpoint instance Id
+     * @param _senderInstanceId - bytes32 indicating the id of the sender's earlybird instance
      * @param _sender - bytes array indicating the address of the receiver
      * @param _nonce - uint256 indicating the nonce
      * @param _payload - bytes array containing message payload
@@ -28,7 +28,7 @@ interface IRecsContractForThunderbirdReceiveModule {
 
     /**
      * @dev - function returns the amount an oracle is willing to charge for passing a message
-     * @param _senderInstanceId - bytes32 indicating the receiver's earlybird endpoint instance Id
+     * @param _senderInstanceId - bytes32 indicating the id of the sender's earlybird instance
      * @param _sender - bytes array indicating the address of the receiver
      * @param _nonce - uint256 indicating the nonce
      * @param _payload - bytes array containing message payload

--- a/src/Libraries/Thunderbird/ThunderbirdReceiveModule/IThunderbirdReceiveModule.sol
+++ b/src/Libraries/Thunderbird/ThunderbirdReceiveModule/IThunderbirdReceiveModule.sol
@@ -11,7 +11,7 @@ import "../../ILibrary/IRequiredReceiveModuleFunctions.sol";
  */
 interface IThunderbirdReceiveModule is IRequiredReceiveModuleFunctions {
     /**
-     * @dev - Enum representing config type being updated
+     * @dev - Enum representing the app config changes that can be made
      * ORACLE_CHANGE - represents the app's oracle being updated.
      * RELAYER_CHANGE - represents the app's default relayer being updated.
      * RECS_CONTRACT_CHANGE - represents the app's default recommendations contract being updated.
@@ -20,7 +20,7 @@ interface IThunderbirdReceiveModule is IRequiredReceiveModuleFunctions {
      * MSG_DELIVERY_PAUSED_STATUS_CHANGE - represents the app's msg delivery status being updated.
      * NONCE_CHANGE - represents the app's msg nonce being updated.
      */
-    enum ConfigType {
+    enum ConfigUpdateType {
         ORACLE_CHANGE,
         RELAYER_CHANGE,
         RECS_CONTRACT_CHANGE,
@@ -47,19 +47,21 @@ interface IThunderbirdReceiveModule is IRequiredReceiveModuleFunctions {
     }
 
     /**
-     * @dev - Struct that represents an app's setting within the Thunderbird receive module
-     * oracle - address of app's selected oracle
-     * relayer - address of app's selected relayer
+     * @dev - Struct that represents an app config within the Thunderbird receive module
+     * oracle - address of oracle from which the app receives message proofs
+     * defaultRelayer - address of app's default relayer.  The default relayer is typically responsible for passing
+     *                  messages to the app except if the application has configured another relayer to pass messages
+     *                  through the variable configs contract.
      * recsContract - address of the contract we can call for recommendations for the values we should pass with the msg proof.
      *                i.e. msg revealed secret, recommended relayer.
-     * emitMsgProofs - bool indicating whether the protocol should broadcast msg proofs when they are submitted by an oracle.
+     * emitMsgProofs - bool indicating whether the protocol should broadcast contents of msg proofs when an oracle submits them.
      * directMsgsEnabled - bool indicating whether the receive module should deliver messages to the app directly or not.
      * msgDeliveryPaused - bool indicating whether msg delivery is paused or not. If paused, the library will not accept new msg
      *                     proofs or deliver messages to the app.
      */
-    struct AppSettings {
+    struct AppConfig {
         address oracle;
-        address relayer;
+        address defaultRelayer;
         address recsContract;
         bool emitMsgProofs;
         bool directMsgsEnabled;

--- a/src/Libraries/Thunderbird/ThunderbirdSendModule/IThunderbirdSendModule.sol
+++ b/src/Libraries/Thunderbird/ThunderbirdSendModule/IThunderbirdSendModule.sol
@@ -11,13 +11,13 @@ import "../../ILibrary/IRequiredSendModuleFunctions.sol";
  */
 interface IThunderbirdSendModule is IRequiredSendModuleFunctions {
     /**
-     * @dev - Enum representing config type the app would like updated.
+     * @dev - Enum representing the app config changes that can be made
      * BROADCAST_STATUS_CHANGE - represents broadcasting status being updated
-     * ORACLE_CHANGE - represents oracle address being updated
-     * RELAYER_CHANGE - represents relayer address being updated
+     * ORACLE_CHANGE - represents oracle fee collector address being updated
+     * RELAYER_CHANGE - represents relayer fee collector address being updated
      * NONCE_CHANGE - represents the app's msg nonce being updated.
      */
-    enum ConfigType {
+    enum ConfigUpdateType {
         BROADCAST_STATUS_CHANGE,
         ORACLE_CHANGE,
         RELAYER_CHANGE,
@@ -45,17 +45,17 @@ interface IThunderbirdSendModule is IRequiredSendModuleFunctions {
     /**
      * @dev - Struct representing an app's settings
      * isSelfBroadcasting - bool on whether the app is self broadcasting or not.
-     * oracle - address of app's selected oracle
-     * relayer - address of app's selected relayer
+     * oracleFeeCollector - address to which the app will pay oracle fees
+     * relayerFeeCollector - address to which the app will pay relayer fees
      */
-    struct AppSettings {
+    struct AppConfig {
         bool isSelfBroadcasting;
-        address oracle;
-        address relayer;
+        address oracleFeeCollector;
+        address relayerFeeCollector;
     }
 
     /**
-     * @dev - Struct representing an app's settings
+     * @dev - Struct for tracking nonces for ordered and unordered messages
      * ordered - uint256 indicating nonce for ordered messages.  Starts from 0 and goes to 2**256 – 1.
      * unordered - uint256 indicating nonce for unordered messages. Starts from 2**256 – 1 and goes to 0.
      */
@@ -125,16 +125,16 @@ interface IThunderbirdSendModule is IRequiredSendModuleFunctions {
     /**
      * @dev - Event emitted when you self broadcast a message
      * @param msgHash - hash of the msg that the app delivered
-     * @param oracle - oracle address
-     * @param relayer - relayer address
+     * @param oracleFeeCollector - address to which oracle fees were paid
+     * @param relayerFeeCollector - address to which relayer fees were paid
      * @param feeToken - token that the fee was paid in
      * @param oracleFee - fee paid to the oracle
      * @param relayerFee - fee paid to the relayer
      */
     event OracleAndRelayerPaid(
         bytes32 indexed msgHash,
-        address indexed oracle,
-        address indexed relayer,
+        address indexed oracleFeeCollector,
+        address indexed relayerFeeCollector,
         address feeToken,
         uint256 oracleFee,
         uint256 relayerFee


### PR DESCRIPTION
consistent usage of "app config" which was previously referred to as app config and app settings
this includes renaming "sendModuleConfigs" and "receiveModuleConfigs" to "appConfigForSending" and "appConfigForReceiving"

refer to the "sending oracle" (which is a  contract that implements the FeeCollector interface) as the oracleFeeCollector, and the same for relayer

standardize some function signature description verbiage
rewrite some function signature description verbiage
fix some function signature description verbiage